### PR TITLE
Update protobuf-compiler to version 3.11.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,10 @@ ENV JENKINS_HOME /var/jenkins_home
 
 # install dependecies
 RUN apt-get update && apt-get install -y \
-    curl autoconf make git libgit2-dev libio-captureoutput-perl virtualenv tar build-essential pkg-config protobuf-compiler \
+    curl unzip autoconf make git libgit2-dev libio-captureoutput-perl virtualenv tar build-essential pkg-config \
     && rm -rf /var/lib/apt/lists/*
+RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip
+RUN unzip -o protoc-3.11.4-linux-x86_64.zip -d /usr/local bin/protoc
 
 # set up golang
 ENV GO_VERSION=1.12.4


### PR DESCRIPTION
Apt-get install protobuf-compiler installs version 3.0.0
Since we updated the version of protobuf-compiler in the
installation guide to 3.11.4, the version should also be
updated here